### PR TITLE
Improve resource selection from semantic container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This connector is designed to read data from a [semantic container](https://www.
 For more information please refer to the Curious Containers [documentation](https://www.curious-containers.cc/).
 
 ## Limitations / Future Work
-- Only handles json data from Semantic Container. No other format or binary data is supported.
+- Selections within the content of a data entry are partially supported in json format. For any other format this is currently not possible.
 
 ## Acknowledgements
 

--- a/red_connector_semcon/commons/helpers.py
+++ b/red_connector_semcon/commons/helpers.py
@@ -131,7 +131,7 @@ def fetch_file(file_path, url, http_method, headers, params, verify=True, data_k
         if isinstance(data, dict):
             data = data[data_key]
         else:
-            raise InvalidDataException('Cannot fetch data key from a list. To use the data key, select a specific resource with its id or dri!')
+            raise InvalidDataException('Data key can only be fetched from a dictonary.')
 
     with open(file_path, 'w') as f:
         if isinstance(data, str) and not file_path.endswith('.json'):  # dump strings as plain files. Not as json.

--- a/red_connector_semcon/commons/schemas.py
+++ b/red_connector_semcon/commons/schemas.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 _HTTP_METHODS = ['Get', 'Put', 'Post']
 _HTTP_METHODS_ENUMS = deepcopy(_HTTP_METHODS) + [m.lower() for m in _HTTP_METHODS] + [m.upper() for m in _HTTP_METHODS]
 
+_OUTPUT_FORMAT_ENUMS = ['plain', 'full', 'meta', 'validation']
+
 SCHEMA = {
     'type': 'object',
     'properties': {
@@ -19,9 +21,20 @@ SCHEMA = {
             'additionalProperties': False,
             'required': ['username', 'password']
         },
-        'key': {'type': 'string'},
+        'resource': {
+            'type': 'object',
+            'properties': {
+                'id': {'type': 'string'},
+                'dri': {'type': 'string'},
+                'schemaDri': {'type': 'string'},
+                'tableName': {'type': 'string'},
+                'key': {'type': 'string'},
+                'format': {'enum': _OUTPUT_FORMAT_ENUMS}
+            },
+            'additionalProperties': False
+        },
         'disableSSLVerification': {'type': 'boolean'}
     },
     'additionalProperties': False,
-    'required': ['url', 'key']
+    'required': ['url']
 }

--- a/red_connector_semcon/commons/schemas.py
+++ b/red_connector_semcon/commons/schemas.py
@@ -4,9 +4,10 @@ from copy import deepcopy
 _HTTP_METHODS = ['Get', 'Put', 'Post']
 _HTTP_METHODS_ENUMS = deepcopy(_HTTP_METHODS) + [m.lower() for m in _HTTP_METHODS] + [m.upper() for m in _HTTP_METHODS]
 
+_RESOURCE_TYPE_ENUMS = ['id', 'dri', 'schema_dri', 'table']
 _OUTPUT_FORMAT_ENUMS = ['plain', 'full', 'meta', 'validation']
 
-SCHEMA = {
+_BASE_SCHEMA = {
     'type': 'object',
     'properties': {
         'url': {'type': 'string'},
@@ -21,20 +22,33 @@ SCHEMA = {
             'additionalProperties': False,
             'required': ['username', 'password']
         },
-        'resource': {
-            'type': 'object',
-            'properties': {
-                'id': {'type': 'string'},
-                'dri': {'type': 'string'},
-                'schemaDri': {'type': 'string'},
-                'tableName': {'type': 'string'},
-                'key': {'type': 'string'},
-                'format': {'enum': _OUTPUT_FORMAT_ENUMS}
-            },
-            'additionalProperties': False
-        },
         'disableSSLVerification': {'type': 'boolean'}
     },
     'additionalProperties': False,
     'required': ['url']
+}
+
+RECEIVE_FILE_SCHEMA = deepcopy(_BASE_SCHEMA)
+RECEIVE_FILE_SCHEMA['resource'] = {
+    'type': 'object',
+    'properties': {
+        'resource_type': {'enum': _RESOURCE_TYPE_ENUMS},
+        'resource_value': {'type': 'string'},
+        'key': {'type': 'string'},
+        'format': {'enum': _OUTPUT_FORMAT_ENUMS}
+    },
+    'additionalProperties': False,
+    'required': ['resource_type', 'resource_value']
+}
+
+SEND_FILE_SCHEMA = deepcopy(_BASE_SCHEMA)
+RECEIVE_FILE_SCHEMA['resource'] = {
+    'type': 'object',
+    'properties': {
+        'dri': {'type': 'string'},
+        'schema_dri': {'type': 'string'},
+        'table': {'type': 'string'},
+        'key': {'type': 'string'}
+    },
+    'additionalProperties': False
 }

--- a/red_connector_semcon/commons/schemas.py
+++ b/red_connector_semcon/commons/schemas.py
@@ -42,7 +42,7 @@ RECEIVE_FILE_SCHEMA['resource'] = {
 }
 
 SEND_FILE_SCHEMA = deepcopy(_BASE_SCHEMA)
-RECEIVE_FILE_SCHEMA['resource'] = {
+SEND_FILE_SCHEMA['resource'] = {
     'type': 'object',
     'properties': {
         'dri': {'type': 'string'},

--- a/red_connector_semcon/commons/schemas.py
+++ b/red_connector_semcon/commons/schemas.py
@@ -29,25 +29,25 @@ _BASE_SCHEMA = {
 }
 
 RECEIVE_FILE_SCHEMA = deepcopy(_BASE_SCHEMA)
-RECEIVE_FILE_SCHEMA['resource'] = {
+RECEIVE_FILE_SCHEMA['properties']['resource'] = {
     'type': 'object',
     'properties': {
-        'resource_type': {'enum': _RESOURCE_TYPE_ENUMS},
-        'resource_value': {'type': 'string'},
+        'resourceType': {'enum': _RESOURCE_TYPE_ENUMS},
+        'resourceValue': {'type': 'string'},
         'key': {'type': 'string'},
         'format': {'enum': _OUTPUT_FORMAT_ENUMS}
     },
     'additionalProperties': False,
-    'required': ['resource_type', 'resource_value']
+    'required': ['resourceType', 'resourceValue']
 }
 
 SEND_FILE_SCHEMA = deepcopy(_BASE_SCHEMA)
-SEND_FILE_SCHEMA['resource'] = {
+SEND_FILE_SCHEMA['properties']['resource'] = {
     'type': 'object',
     'properties': {
         'dri': {'type': 'string'},
-        'schema_dri': {'type': 'string'},
-        'table': {'type': 'string'},
+        'schemaDri': {'type': 'string'},
+        'tableName': {'type': 'string'},
         'key': {'type': 'string'}
     },
     'additionalProperties': False

--- a/red_connector_semcon/semcon/send_receive_file.py
+++ b/red_connector_semcon/semcon/send_receive_file.py
@@ -25,9 +25,32 @@ def _receive_file(access, local_file_path):
     http_method = http_method_func(access, 'GET')
     access_token = oauth_token(access, verify)
     headers = bearer_auth_header(access_token)
-    data_key = access.get('key')
+    
+    url = access['url']
+    data_key = None
+    params = {}
+    
+    if access.get('resource'):
+        resource = access['resource']
+        
+        if resource.get('key'):
+            data_key = resource['key']
+        
+        if resource.get('id'):
+            url = url.strip('/') + f"/{resource['id']}"
+            params['p'] = 'id'
+        elif resource.get('dri'):
+            url = url.strip('/') + f"/{resource['dri']}"
+            params['p'] = 'dri'
+        else:
+            if resource.get('schemaDri'):
+                params['schema_dri'] = resource['schemaDri']
+            if resource.get('tableName'):
+                params['table'] = resource['tableName']
+        
+        params['f'] = resource.get('format', 'plain')
 
-    fetch_file(local_file_path, access['url'], http_method, headers, verify, data_key)
+    fetch_file(local_file_path, url, http_method, headers, params, verify, data_key)
 
 
 def _receive_file_validate(access):
@@ -48,17 +71,42 @@ def _send_file(access, local_file_path):
     http_method = http_method_func(access, 'POST')
     access_token = oauth_token(access, verify)
     headers = bearer_auth_header(access_token)
-    data_key = access.get('key')
-
+    
+    data_key = None
+    write_data = {}
+    
+    if access.get('resource'):
+        resource = access['resource']
+        
+        if resource.get('key'):
+            data_key = resource['key']
+        
+        if resource.get('dri'):
+            write_data['dri'] = resource['dri']
+        if resource.get('schemaDri'):
+            write_data['schema_dri'] = resource['schemaDri']
+        if resource.get('tableName'):
+            write_data['table_name'] = resource['tableName']
+    
+    
     with open(local_file_path, 'rb') as f:
-        r = http_method(
-            access['url'],
-            data={data_key: f.read()},
-            headers=headers,
-            verify=verify,
-            timeout=DEFAULT_TIMEOUT
-        )
-        r.raise_for_status()
+        content = json.loads(f.read())
+        if data_key is None:
+            write_data['content'] = content
+        else:
+            write_data['content'] = {
+                data_key: content
+            }
+    print(write_data)
+    
+    r = http_method(
+        access['url'],
+        json=write_data,
+        headers=headers,
+        verify=verify,
+        timeout=DEFAULT_TIMEOUT
+    )
+    r.raise_for_status()
 
 
 def _send_file_validate(access):

--- a/test_files/access/input.json
+++ b/test_files/access/input.json
@@ -4,6 +4,10 @@
     "password": "testpassword",
     "scope": "read"
   },
-  "url": "http://localhost:3000/api/data",
-  "key": "executable"
+  "resource": {
+    "resourceType": "id",
+    "resourceValue": "1",
+    "format": "plain"
+  },
+  "url": "http://localhost:3000/api/data"
 }

--- a/test_files/access/send1.json
+++ b/test_files/access/send1.json
@@ -4,6 +4,10 @@
     "password": "testpassword",
     "scope": "write"
   },
-  "url": "http://localhost:3000/api/data",
-  "key": "postkey"
+  "resource": {
+    "dri": "0",
+    "schemaDri": "bar",
+    "tableName": "default"
+  },
+  "url": "http://localhost:3000/api/data"
 }

--- a/test_files/send_files/send2.txt
+++ b/test_files/send_files/send2.txt
@@ -1,0 +1,6 @@
+{
+    "size": "32",
+    "eye_color": "green",
+    "hair": "long",
+    "name": "foo"
+}


### PR DESCRIPTION
Added features
- selection of all content in one data entry
- selection of content that is not in json format
- select data entry by id or dri
- select whole table or schema by table name or schema dri
- specifiy output format (plain, full, meta, validation)
- add possibility to sepcify an dri, table and schema_dri when sending data to the semantic container

Changes to the schema (the new scheme is not backwards compatible with previous versions!)
- schema was split into receive_file and send_file schema
- added key resourceType, resourceValue and format to receive_file schema
- added key dri, schemaDri and tableName to receive_file schema
- moved key 'key' inside resource object
- key 'key' is now optional